### PR TITLE
fixed wrong wording around JLReq Fig 241 example

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
       </section>
 
       <section>
-        <h3>Ruby to indicate the reading of a foreign phrase in language textbooks </h3>
+        <h3>Ruby to indicate the reading of a foreign phrase in language textbooks</h3>
         <p>
           In language textbooks, ruby is sometimes used to indicate the reading of a foreign phrase in hiragana or katakana. 
           For example, a Chinese phrase <span lang="zh-hans">我去学校</span> may have <span lang="ja">ウオ チュー シュエシャオ</span> as ruby.
@@ -325,9 +325,9 @@
             The option of reading aloud both is sensible.
           </p>
           <p>
-            For example, <span lang="ja"><ruby><rb>徳川家康</rb><rt>1543-1616 江戸幕府最後の将軍</rt></ruby></span> 
-            is read aloud as "Tokugawa Ieyasu 1543-1616 Edo Bakufu Saigono Shougun", 
-            which means "Tokugawa Ieyasu 1543-1616, the last shogun of the Edo shogunate".        
+            For example, <span lang="ja"><ruby><rb>徳川慶喜</rb><rt>1837-1913 江戸幕府最後の将軍</rt></ruby></span> 
+            is read aloud as "Tokugawa Yoshinobu 1837-1913 Edo Bakufu Saigono Shougun", 
+            which means "Tokugawa Yoshinobu 1837-1913, the last shogun of the Edo shogunate".        
           </p>
         </section>
 
@@ -424,9 +424,9 @@
           </p>
           <p>
             If <span lang="ja">"1837-1913 江戸幕府最後の将軍"</span> is attached to <span lang="ja">徳川慶喜</span> as ruby, 
-            it will be read aloud as <span lang="ja">"1543-1616 エドバクフサイゴノショウグン"</span> 
-            (1543-1616 the last shogun of the Edo shogunate), which is reasonable.
-            But if only "1543-1616" is attached as ruby, the result is "1543-1616" which does not make any sense.
+            it will be read aloud as <span lang="ja">"1837-1913 エドバクフサイゴノショウグン"</span> 
+            (1837-1913 the last shogun of the Edo shogunate), which is reasonable.
+            But if only "1837-1913" is attached as ruby, the result is "1837-1913" which does not make any sense.
           </p>
         </section>
 
@@ -519,8 +519,8 @@
           </p>
           <p>
             <span lang="ja"><ruby><rb>徳川慶喜</rb><rt>1837-1913 江戸幕府最後の将軍</rt></ruby></span>
-              (Tokugawa Yoshinobu 1543-1616, the last shogun of the Edo shogunate), 
-              will be read aloud as <span lang="ja">とくがわいえのぶ</span> (Tokugawa Yoshinobu).
+              (Tokugawa Yoshinobu 1837-1913, the last shogun of the Edo shogunate), 
+              will be read aloud as <span lang="ja">とくがわよしのぶ</span> (Tokugawa Yoshinobu).
           </p>
         </section>
 


### PR DESCRIPTION
closes #3


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/ruby-t2s-req/pull/16.html" title="Last updated on Dec 22, 2021, 7:14 AM UTC (3a8ccf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/16/8034136...himorin:3a8ccf9.html" title="Last updated on Dec 22, 2021, 7:14 AM UTC (3a8ccf9)">Diff</a>