### PR TITLE
Rewrite of the section "Alternatives to ruby" thoroughly.

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,19 @@
             publisher: "W3C",
             date: "08 May 2019",
           },
-        },
+	  JEITA_IT-4002: {
+	      title: "Symbols for Japanese Text-to-Speech Synthesizer",
+	      id:  "JEITA IT-4002",
+	      date: "May 2005",
+	      publisher: "Japan Electronics and Information Technology Industries Association",
+	  },
+	  JEITA_IT-4006: {
+	      title: "Symbols for Japanese Text-to-Speech Synthesizer",
+	      id:  "JEITA IT-4006",
+	      date: "March 2010",
+	      publisher: "Japan Electronics and Information Technology Industries Association",
+	  },
+	},
         xref: true,
         postProcess: [  ],
       };
@@ -637,23 +649,23 @@
       <section>
         <h3>SSML</h3>
         <p>
-	  [[?SSML]] uses symbol collections (such as IPA and JEITA
-	  IT-4006) to represent the sounds of human languages.
+	  [[?SSML]] uses symbol collections (such as IPA and
+	  [[?JEITA_IT-4006]]) to represent the sounds of human languages.
 	  Phonemic/phonetic pronunciation is represented by sequences
 	  of such symbols.
         </p>  
         <p>
-	  EPUB 3 allows SSML attributes to be used within XHTML content
+	  [[?epub-32]] allows SSML attributes to be used within XHTML content
 	  documents in EPUB publications.  In the upcoming version,
-	  EPUB 3.3, these attributes are moved to [[epub-tts-10]].
+	  [[?epub-33]], these attributes are moved to [[?epub-tts-10]].
 	  Meanwhile, the W3C Accessible Platform Architectures Working
-	  Group is developing [[spoken-html]].  [[spoken-html]] describes
+	  Group is developing [[?spoken-html]], which describes
 	  two possible approaches for adding SSML attributes to HTML elements.
         </p>
         <p>
-	  [[?SSML]] is widely used for digital textbooks by more than
+	  SSML is widely used for digital textbooks by more than
           one textbook publisher in Japan.  Meanwhile, it has been
-          reported that attaching [[?SSML]] attributes to CJK
+          reported that attaching SSML attributes to CJK
           ideographic characters significantly increases the authoring
           cost.  DAISY textbooks in Japan do not use SSML, since they
           include recorded voice.  Trade books in Japan do not use
@@ -665,7 +677,7 @@
         <h3>PLS</h3>
 	<p>PLS ([[PRONUNCIATION-LEXICON]]) allows for pronunciation lexicons, which maps words to
 	  sequences of symbol collections such as those in IPA or
-	  JEITA IT-4006.
+	  [[?JEITA_IT-4006]].
 	  </p>
         <p>
           While [[?SSML]] attributes are embedded within XHTML content

--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
       <h2>Alternatives to ruby</h2>
 
       <p>[[?SSML]] and [[?PRONUNCIATION-LEXICON]] can be used for
-      providing phonemic/phonetic pronunciation of CJK ideograph
+      providing phonemic/phonetic pronunciation of CJK ideographic
       characters to speech synthesis engines.  They are not for visual
       presentations but can control text-to-speech much better than
       ruby.</p>

--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
 	  of such symbols.
         </p>  
         <p>
-	  EPUB 3 allows SSML attributes to be used within HTML content
+	  EPUB 3 allows SSML attributes to be used within XHTML content
 	  documents in EPUB publications.  In the upcoming version,
 	  EPUB 3.3, these attributes are moved to [[epub-tts-10]].
 	  Meanwhile, the W3C Accessible Platform Architectures Working
@@ -668,10 +668,10 @@
 	  JEITA IT-4006.
 	  </p>
         <p>
-          While [[?SSML]] attributes are embedded within HTML content
+          While [[?SSML]] attributes are embedded within XHTML content
           documents in EPUB publications, PLS dictionaries (see
           [[?PRONUNCIATION-LEXICON]]) in EPUB publications are stored
-          externally to and referenced by HTML content documents
+          externally to and referenced by XHTML content documents
           (see <a data-cite="epub-tts-10#pls">Pronunciation Lexicons
           section</a> in [[?epub-tts-10]]).  As of now,
           [[spoken-html]] does not have a mechanism for associationg

--- a/index.html
+++ b/index.html
@@ -663,7 +663,7 @@
 
       <section>
         <h3>PLS</h3>
-	<p>PLS allows for pronunciation lexicons, which maps words to
+	<p>PLS ([[PRONUNCIATION-LEXICON]]) allows for pronunciation lexicons, which maps words to
 	  sequences of symbol collections such as those in IPA or
 	  JEITA IT-4006.
 	  </p>
@@ -678,10 +678,10 @@
           PLS lexicons to HTML documents.
         </p>
         <p>
-          [[?PLS]] is a powerful mechanism for the text-to-speech of
+          PLS is a powerful mechanism for the text-to-speech of
 	  unusual names of people and places.  In particular, every
 	  occurrence of a word or phrase is read aloud in the same way
-	  regardless of the existence of ruby.  As of now, [[?PLS]] is
+	  regardless of the existence of ruby.  As of this writing, PLS is
 	  used by at least one digital textbook publisher in Japan.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -628,31 +628,61 @@
     <section>
       <h2>Alternatives to ruby</h2>
 
+      <p>[[?SSML]] and [[?PRONUNCIATION-LEXICON]] can be used for
+      providing phonemic/phonetic pronunciation of CJK ideograph
+      characters to speech synthesis engines.  They are not for visual
+      presentations but can control text-to-speech much better than
+      ruby.</p>
+      
       <section>
         <h3>SSML</h3>
         <p>
-          In EPUB publications, [[?SSML]] attributes can be attached to XHTML elements for specifying phonemic/phonetic pronunciations. 
-          [[?SSML]] attributes are used by text-to-speech engines for speech synthesis but they are not used for visual rendering. 
-          [[?SSML]] can control text-to-speech much better than ruby.
+	  [[?SSML]] uses symbol collections (such as IPA and JEITA
+	  IT-4006) to represent the sounds of human languages.
+	  Phonemic/phonetic pronunciation is represented by sequences
+	  of such symbols.
+        </p>  
+        <p>
+	  EPUB 3 allows SSML attributes to be used within HTML content
+	  documents in EPUB publications.  In the upcoming version,
+	  EPUB 3.3, these attributes are moved to [[epub-tts-10]].
+	  Meanwhile, the W3C Accessible Platform Architectures Working
+	  Group is developing [[spoken-html]].  [[spoken-html]] describes
+	  two possible approaches for adding SSML attributes to HTML elements.
         </p>
         <p>
-          However, it has been reported that attaching [[?SSML]] to CJK ideographic characters thoroughly significantly 
-          increases the authoring cost. 
-          Although [[?SSML]] has been used by some textbook publishers in Japan, it is unlikely to be widely used for trade books.      
+	  [[?SSML]] is widely used for digital textbooks by more than
+          one textbook publisher in Japan.  Meanwhile, it has been
+          reported that attaching [[?SSML]] attributes to CJK
+          ideographic characters significantly increases the authoring
+          cost.  DAISY textbooks in Japan do not use SSML, since they
+          include recorded voice.  Trade books in Japan do not use
+          SSML either.
         </p>
       </section>
 
       <section>
         <h3>PLS</h3>
+	<p>PLS allows for pronunciation lexicons, which maps words to
+	  sequences of symbol collections such as those in IPA or
+	  JEITA IT-4006.
+	  </p>
         <p>
-          While [[?SSML]] attributes are embedded within [[?XHTML2]] content documents in EPUB publications, 
-          PLS dictionaries (see [[?PRONUNCIATION-LEXICON]]) in EPUB publications are stored externally 
-          to and referenced by XHTML content documents (see <a data-cite="epub-tts-10#pls">Pronunciation Lexicons section</a> in [[?epub-tts-10]]). 
-          A PLS dictionary contains a collection of words or phrases containing pronunciation information.
+          While [[?SSML]] attributes are embedded within HTML content
+          documents in EPUB publications, PLS dictionaries (see
+          [[?PRONUNCIATION-LEXICON]]) in EPUB publications are stored
+          externally to and referenced by HTML content documents
+          (see <a data-cite="epub-tts-10#pls">Pronunciation Lexicons
+          section</a> in [[?epub-tts-10]]).  As of now,
+          [[spoken-html]] does not have a mechanism for associationg
+          PLS lexicons to HTML documents.
         </p>
         <p>
-          PLS is a powerful mechanism for the text-to-speech of unusual names of people and places.  
-          Every occurrence of a word or phrase is read aloud in the same way regardless of ruby.
+          [[?PLS]] is a powerful mechanism for the text-to-speech of
+	  unusual names of people and places.  In particular, every
+	  occurrence of a word or phrase is read aloud in the same way
+	  regardless of the existence of ruby.  As of now, [[?PLS]] is
+	  used by at least one digital textbook publisher in Japan.
         </p>
       </section>
     </section>


### PR DESCRIPTION
To address #23, I have completely rewritten this section.  But some references are not added yet, since I cannot find them in Specref.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 23, 2022, 4:36 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2FJapan-Daisy-Consortium%2Fruby-t2s-req%2Fd6714ef7fe3fe5cfa5b032bf006524d99288fa35%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: https://rawcdn.githack.com/Japan-Daisy-Consortium/ruby-t2s-req/d6714ef7fe3fe5cfa5b032bf006524d99288fa35/index.html?isPreview=true&publishDate=2022-01-23
ReSpec version: 28.2.2
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27932ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:44)
    at async /u/spec-generator/server.js:203:44

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/ruby-t2s-req%2324.)._
</details>
