### PR TITLE
fixed respecConfig errors at PR #26

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,40 +35,40 @@
             date: "2015",
             href: "https://www.soumu.go.jp/main_content/000354698.pdf",
           },
-          EPUB32: {
+          'epub-32': {
             title: "EPUB 3.2",
             href: "https://www.w3.org/publishing/epub3/epub-spec.html",
             status: "W3C Final Community Group Specification",
             publisher: "W3C",
             date: "08 May 2019",
           },
-          EPUB32Packages: {
+          'epub-32-Packages': {
             title: "EPUB Packages 3.2",
             href: "https://www.w3.org/publishing/epub3/epub-packages.html",
             status: "W3C Final Community Group Specification",
             publisher: "W3C",
             date: "08 May 2019",
           },
-          EPUB32ContentDocs: {
+          'epub-32-ContentDocs': {
             title: "EPUB Content Documents 3.2",
             href: "https://www.w3.org/publishing/epub3/epub-contentdocs.html",
             status: "W3C Final Community Group Specification",
             publisher: "W3C",
             date: "08 May 2019",
           },
-	  JEITA_IT-4002: {
-	      title: "Symbols for Japanese Text-to-Speech Synthesizer",
-	      id:  "JEITA IT-4002",
-	      date: "May 2005",
-	      publisher: "Japan Electronics and Information Technology Industries Association",
-	  },
-	  JEITA_IT-4006: {
-	      title: "Symbols for Japanese Text-to-Speech Synthesizer",
-	      id:  "JEITA IT-4006",
-	      date: "March 2010",
-	      publisher: "Japan Electronics and Information Technology Industries Association",
-	  },
-	},
+          'JEITA_IT-4002': {
+            title: "Symbols for Japanese Text-to-Speech Synthesizer",
+            id:  "JEITA IT-4002",
+            date: "May 2005",
+            publisher: "Japan Electronics and Information Technology Industries Association",
+          },
+          'JEITA_IT-4006': {
+            title: "Symbols for Japanese Text-to-Speech Synthesizer",
+            id:  "JEITA IT-4006",
+            date: "March 2010",
+            publisher: "Japan Electronics and Information Technology Industries Association",
+          },
+        },
         xref: true,
         postProcess: [  ],
       };


### PR DESCRIPTION
fixes errors introduced by #26


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 31, 2022, 1:58 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fruby-t2s-req%2F0f1caf26b7a56f2016a54f81daa2728a27c776e2%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: https://rawcdn.githack.com/w3c/ruby-t2s-req/0f1caf26b7a56f2016a54f81daa2728a27c776e2/index.html?isPreview=true&publishDate=2022-01-31
ReSpec version: 29.0.1
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 28396ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:44)
    at async /u/spec-generator/server.js:203:44

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/ruby-t2s-req%2328.)._
</details>
