### PR TITLE
refer EPUB-33 for XHTML content documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,10 +681,10 @@
 	  [[?JEITA_IT-4006]].
 	  </p>
         <p>
-          While [[?SSML]] attributes are embedded within XHTML content
-          documents in EPUB publications, PLS dictionaries (see
+          While [[?SSML]] attributes are embedded within <a data-cite="epub-33#dfn-xhtml-content-document">XHTML content 
+          documents</a> in EPUB publications, PLS dictionaries (see
           [[?PRONUNCIATION-LEXICON]]) in EPUB publications are stored
-          externally to and referenced by XHTML content documents
+          externally to and referenced by <a data-cite="epub-33#dfn-xhtml-content-document">XHTML content documents</a>
           (see <a data-cite="epub-tts-10#pls">Pronunciation Lexicons
           section</a> in [[?epub-tts-10]]).  As of now,
           [[spoken-html]] does not have a mechanism for associationg

--- a/index.html
+++ b/index.html
@@ -655,8 +655,9 @@
 	  of such symbols.
         </p>  
         <p>
-	  [[?epub-32]] allows SSML attributes to be used within XHTML content
-	  documents in EPUB publications.  In the upcoming version,
+	  [[?epub-32]] allows SSML attributes to be used within 
+      <a data-cite="epub-33#dfn-xhtml-content-document">XHTML content documents</a>
+      in EPUB publications.  In the upcoming version,
 	  [[?epub-33]], these attributes are moved to [[?epub-tts-10]].
 	  Meanwhile, the W3C Accessible Platform Architectures Working
 	  Group is developing [[?spoken-html]], which describes


### PR DESCRIPTION
closes #11

How about to cite epub-33 for `XHTML content document` (they actually defines the term in spec), rather than referring XHTML in HTML spec?

NOTE: need edits for other two parts before merging.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/ruby-t2s-req/pull/29.html" title="Last updated on Mar 3, 2022, 4:29 AM UTC (6659d72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/29/bb57b96...himorin:6659d72.html" title="Last updated on Mar 3, 2022, 4:29 AM UTC (6659d72)">Diff</a>