### PR TITLE
Replace some occurrences of "ruby" with "ruby annotation(s)".

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
         <p>
           Especially in Japan, ruby annotations are
 	  also used to indicate something different from the reading of a CJK ideographic character.
-          Such ruby is referred to as <dfn>Gikun</dfn>.  Gikun is commonly employed in light novels and comics. 
+          Such ruby annotations are referred to as <dfn>Gikun</dfn>.  Gikun is commonly employed in light novels and comics. 
         </p>
         <p>
           Here are some examples of Gikun:
@@ -274,7 +274,7 @@
           A sequence of characters can be accompanied by two ruby annotations,
 	  typically consisting of [=Furigana=] and either [=GIKUN=] or an [=interlinear note=].  
           In <a data-cite="JLREQ#fig2_3_12">an example provided in JLreq</a> 
-          ("An example of ruby attached to both sides of the base characters"), 
+          ("An example of ruby annotations attached to both sides of the base characters"), 
           <span lang="ja">東南</span> is accompanied by <span lang="ja">たつみ</span> and <span lang="ja">とうなん</span>. 
           Here <span lang="ja">東南</span> means 'southeast', with <span lang="ja">とうなん</span> (TOUNAN) serving as [=Furigana=], 
           and <span lang="ja">たつみ</span> (TATSUMI) as [=GIKUN=], 
@@ -682,7 +682,7 @@
       <p>[[?SSML]] and [[?PRONUNCIATION-LEXICON]] offer alternatives for
       conveying phonemic and phonetic pronunciations of CJK ideographic 
       characters to speech synthesis engines. These methods are not intended for visual 
-      presentations but can offer superior control over text-to-speech compared to using ruby.</p>
+      presentations but can offer superior control over text-to-speech compared to using ruby annotations.</p>
       
       <section>
         <h3>SSML</h3>
@@ -733,7 +733,7 @@
 	  PLS is a robust tool for rendering unusual names of people
 	  and places in text-to-speech applications.  In particular, PLS allows
 	  every occurrence of a word or phrase to be consistently pronounced, 
-	  regardless of the presence of ruby.  At the time of this writing, PLS is
+	  regardless of the presence of ruby annotations.  At the time of this writing, PLS is
 	  used by at least one digital textbook publisher in Japan.
         </p>
       </section>
@@ -774,7 +774,7 @@
 	essential to select the correct reading for each CJK
 	ideographic character. Choosing an incorrect reading can
 	result in erroneous braille output. Similar to text-to-speech,
-	ruby provides valuable hints, while [[?SSML]] and PLS
+	ruby annotations provide valuable hints, while [[?SSML]] and PLS
 	([[?PRONUNCIATION-LEXICON]]) serve as effective alternatives.
       </p>
       <p>


### PR DESCRIPTION
This is to address #36.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/pull/53.html" title="Last updated on May 21, 2024, 12:03 AM UTC (c0fabd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/53/54216aa...c0fabd9.html" title="Last updated on May 21, 2024, 12:03 AM UTC (c0fabd9)">Diff</a>