### PR TITLE
Change shortname to ruby-tts-reqs

### DIFF
--- a/ECHIDNA
+++ b/ECHIDNA
@@ -1,3 +1,0 @@
-index.html?specStatus=WD&shortName=ruby-t2s-req respec
-img/rdr001.png
-img/rdr002.png

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ruby-t2s-req
+# ruby-tts-reqs
 
 Text to Speech of Electronic Documents Containing Ruby: User Requirements
 
@@ -6,10 +6,11 @@ This document describes user requirements for text to speech of electronic docum
 and is developed under [Japanese Layout Task Force](https://www.w3.org/groups/tf/i18n-jlreq). 
 Check [README of Japanese Language Enablement repository](https://github.com/w3c/jlreq/blob/gh-pages/README.md) for providing feedbacks or participating.
 
-- Editor's draft: https://w3c.github.io/ruby-t2s-req/
-- Working Draft: https://www.w3.org/TR/ruby-t2s-req/ (aiming Internationalization WG NOTE, but not yet published)
+- Editor's draft: https://w3c.github.io/ruby-tts-reqs/
+- Draft NOTE: https://www.w3.org/TR/ruby-tts-reqs/ (aiming Internationalization WG NOTE, but not yet published)
 
 
 ## Milestone
 
 MM create a milestone for the first publication as a W3C Note and chose some issues for it.
+

--- a/index.html
+++ b/index.html
@@ -10,16 +10,16 @@
     ></script>
     <script class="remove">
       var respecConfig = {
-        shortName: "ruby-t2s-req",
+        shortName: "ruby-tts-reqs",
         specStatus: "ED", // "WG-NOTE"
         noRecTrack: true,
-        edDraftURI: "https://w3c.github.io/ruby-t2s-req/",
+        edDraftURI: "https://w3c.github.io/ruby-tts-reqs/",
         editors: [
           { name: "MURATA Makoto [FAMILLY Given]", company: "DAISY Consortium", w3cid: "32937", },
         ],
         group: "i18n",
         github: {
-          repoURL: "w3c/ruby-t2s-req",
+          repoURL: "w3c/ruby-tts-reqs",
           branch: "gh-pages",
         },
         localBiblio: {

--- a/w3c.json
+++ b/w3c.json
@@ -1,6 +1,6 @@
 	{
         "group":      109193
     ,   "contacts":   ["rishida", "himorin"]
-    ,   "shortName":  "ruby-t2s-req"
+    ,   "shortName":  "ruby-tts-reqs"
     ,	"policy":	  "restricted"
     }


### PR DESCRIPTION
closes #66

to be merged after all agreed and prepared, incl. github repository name changed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/pull/70.html" title="Last updated on Nov 3, 2025, 3:55 PM UTC (311d55b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/70/0058a4e...311d55b.html" title="Last updated on Nov 3, 2025, 3:55 PM UTC (311d55b)">Diff</a>