### PR TITLE
Replacing interline by interlinear

### DIFF
--- a/index.html
+++ b/index.html
@@ -684,7 +684,7 @@ of reading both ruby bases and annotations.
           <h4 id="interlinear_note_base_read_aloud">Interlinear notes, when bases read aloud</h4>
           <p>
             The option of reading ruby bases only provides a perfectly understandable result. 
-            However, since interline notes are ignored, the author's intention is not conveyed well.
+            However, since interlinear notes are ignored, the author's intention is not conveyed well.
           </p>
           <p>
             <span lang="ja"><ruby><rb>徳川慶喜</rb><rt>1837-1913 江戸幕府最後の将軍</rt></ruby></span>
@@ -777,7 +777,7 @@ it becomes easier for the text-to-speech engine to maintain a correspondence tab
       <section>
         <h3>Distinguishing ruby annotations used as gikun or interlinear notes</h3>
         <p>
-          In Section 3, we have seen that ruby annotations used as gikun or interline notes should be read aloud differently from the other cases. 
+          In Section 3, we have seen that ruby annotations used as gikun or interlinear notes should be read aloud differently from the other cases. 
           Therefore, it is necessary to be able to distinguish ruby annotations used as gikun or interlinear notes from other ruby annotations, in order to ensure appropriate reading behavior.
         </p>
       </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/pull/74.html" title="Last updated on Dec 22, 2025, 11:30 AM UTC (571bd6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/74/0fc1eb8...571bd6f.html" title="Last updated on Dec 22, 2025, 11:30 AM UTC (571bd6f)">Diff</a>