### PR TITLE
Drop foreign phrase

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,13 +270,21 @@
       </section>
 
       <section>
-        <h3>Ruby annotations for indicating the pronunciation of foreign phrases in language textbooks, background</h3>
+        <h3>Others</h3>
         <p>
-	  In language textbooks, ruby annotations are at times
-	  employed to indicate the pronunciation of foreign phrases
-	  written in hiragana or katakana. For example, a Chinese
-	  phrase <span lang="zh-hans">我去学校</span> may include
-	  <span lang="ja">ウオ チュー シュエシャオ</span> as a ruby annotation.
+	  Ruby annotations can be used for purposes other than
+	  indicating the reading of CJK ideographic text. For example,
+	  they may be applied to foreign-language text written in
+	  non-native scripts, chemical formulas, mathematical
+	  expressions, or other specialized notations, in order to
+	  convey pronunciation or supplementary information.</p>
+
+	<p>
+	  However, such uses of ruby annotations fall outside the
+	  scope of this note. This document focuses exclusively on
+	  ruby annotations associated with CJK ideographic text, where
+	  language-dependent reading behavior and accessibility
+	  considerations raise specific and non-trivial issues.
         </p>
       </section>
 
@@ -404,19 +412,6 @@ of reading both ruby bases and annotations.
             For example, <span lang="ja"><ruby><rb>徳川慶喜</rb><rt>1837-1913 江戸幕府最後の将軍</rt></ruby></span> 
             is read aloud as TOKUGAWA YOSHINOBU 1837-1913 EDO BAKUFU SAIGONO SHOUGUN, 
             which means 'Tokugawa Yoshinobu 1837-1913, the last shogun of the Edo shogunate'.        
-          </p>
-        </section>
-
-        <section>
-          <h4>Ruby annotations for indicating the pronunciation of foreign phrases in language books, when both read aloud</h4>
-          <p>
-            The option of reading aloud both interferes with readers' understanding significantly.
-          </p>
-          <p>
-            In the example of <span lang="zh-hans">我去学校</span>, 
-            even if <span lang="ja">ウオ チュー シュエシャオ</span> is read aloud using the Japanese text-to-speech engine, 
-            the result will not be helpful to learners because of the incorrect pronunciation and four tones. 
-            Katakana pronunciation is also useless in languages such as English.
           </p>
         </section>
 
@@ -595,18 +590,6 @@ of reading both ruby bases and annotations.
           </p>
         </section>
 
-        <section>
-          <h4>Ruby annotations for indicating the pronunciation of foreign phrases in language books, when ruby annotations read aloud</h4>
-          <p>
-            The option of reading aloud ruby annotations only interferes with readers' understanding significantly.
-          </p>
-          <p>
-            In the example of <span lang="zh-hans">我去学校</span> (<span lang="ja">ウオ チュー シュエシャオ</span>), 
-            even if <span lang="ja">ウオ チュー シュエシャオ</span> is read out in the Japanese style, 
-            it will not be helpful to learners because of the inaccurate pronunciation and the four tones (tones). 
-            Katakana pronunciation is also useless in languages such as English.
-          </p>
-        </section>
 
         <section>
           <h4>Double-sided ruby, when ruby annotations read aloud</h4>
@@ -693,15 +676,6 @@ of reading both ruby bases and annotations.
           </p>
         </section>
 
-        <section>
-          <h4>Ruby annotations for indicating the pronunciation of foreign phrases in language books, when bases read aloud</h4>
-          <p>
-            The option of reading ruby bases only is most appropriate when natural languages are correctly identified 
-            and ruby bases are read aloud by a text-to-speech engine for that language. 
-            On the other hand, if the natural language cannot be identified or the text-to-speech engine for that language is not available, 
-            the result is not understandable.        
-          </p>
-        </section>
 
         <section>
           <h4>Double-sided ruby, when bases read aloud</h4>


### PR DESCRIPTION
Drop the use of ruby for foreign phrases, just like chemical formulae and math expressions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/pull/75.html" title="Last updated on Dec 23, 2025, 12:22 AM UTC (5509fc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ruby-t2s-req/75/0fc1eb8...5509fc1.html" title="Last updated on Dec 23, 2025, 12:22 AM UTC (5509fc1)">Diff</a>